### PR TITLE
Add section 508 Accessibility markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ class Twitter extends Component {
 }
 ```
 
+#### Accessibility
+
+If you want Section 508 Accessibility add the `title` prop to the `<Svg />` component like this:
+```js
+<Svg title="Image Description" width="1000" height="1000" ... />
+```
+When this renders on native, you'll get your SVG wrapped in a View with an accessibilityLabel.
+On web, the SVG element will get two aria labels and a `<title>` element that are
+required for accessibility.
+```html
+<svg role="img" aria-label="[title]" width="1000" height="1000">
+  <title>Image Description</title>
+  ...
+</svg>
+```
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -227,8 +227,22 @@ function Stop(props) {
  * @public
  */
 function Svg(props) {
-  return <svg { ...prepare(props) } />;
+  const { title, ...rest } = props;
+  if (title) {
+    return (
+      <svg role='img' aria-label='[title]' { ...prepare(rest) }>
+        <title>{title}</title>
+        { props.children }
+      </svg>);
+  }
+  return
+    <svg { ...prepare(rest) } />;
 }
+
+Svg.propTypes = {
+  title: String,
+  desc: String
+};
 
 /**
  * Return a symbol SVG element.

--- a/index.native.js
+++ b/index.native.js
@@ -1,4 +1,5 @@
-import Svg, {
+import React from 'react';
+import RNSvg, {
   Circle,
   ClipPath,
   Defs,
@@ -19,6 +20,19 @@ import Svg, {
   TextPath,
   Use
 } from 'react-native-svg';
+import {View} from 'react-native';
+
+const Svg = (props) => {
+  const {title, ...rest} = props;
+  if (title) {
+    return (
+      <View accessible={true} accessibilityLabel={title}>
+         <RNSvg { ...rest} />
+       </View>
+      );
+    }
+  return <RNSvg { ...rest} />
+};
 
 export {
   Circle,


### PR DESCRIPTION
I work for a government organization that follows strict accessibility requirements.  I was able to modify your great module to properly support these if the user supplies a `title` prop to the Svg element.  I can maintain my own fork, but I think its better to have it merged in.

Thanks