### PR TITLE
Replace textpath with textPath since it is sometimes case-sensitive

### DIFF
--- a/index.js
+++ b/index.js
@@ -293,7 +293,7 @@ TSpan.propTypes = Text.propTypes;
  * @public
  */
 function TextPath(props) {
-  return <textpath { ...prepare(props) } />;
+  return <textPath { ...prepare(props) } />;
 }
 
 /**

--- a/test.js
+++ b/test.js
@@ -286,10 +286,10 @@ describe('@ux/svg', function () {
       assume(TextPath).is.not.a('undefined');
     });
 
-    it('is a textpath', function () {
+    it('is a textPath', function () {
       const name = shallow(<TextPath />).name();
 
-      assume(name).equals('textpath');
+      assume(name).equals('textPath');
     });
   });
 


### PR DESCRIPTION
According to [svg2](https://www.w3.org/TR/2015/WD-SVG2-20150915/text.html) spec, textpath should be textPath.

This is not just a nit-pick, because some browsers will ignore the element if it does not have the correct case. [Here](https://stackoverflow.com/questions/38396007/d3-js-text-on-path-not-rendered-no-height-width) is one example where some random person on the internet ran in this problem in a different context.