### PR TITLE
Add support for x,y in G

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,11 @@ function Ellipse(props) {
  * @public
  */
 function G(props) {
-  return <g { ...prepare(props) } />;
+  const { x, y, ...rest } = props;
+  if ((x || y) && !rest.translate) {
+    rest.translate = `${x || 0}, ${y || 0}`;
+  }
+  return <g { ...prepare(rest) } />;
 }
 
 /**


### PR DESCRIPTION
`react-native-svg` adds `x` and `y` attributes to the `G` component. In the `svg` spec, this doesn't exist and it should be treated as a translation.