### PR TITLE
[fix] Do no prefix `none` for preserveAspectRatio see #21

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function prepare(props) {
   //
   const preserve = clean.preserveAspectRatio;
   if (preserve && preserve !== 'none' && !~preserve.indexOf(' ')) {
-    clean.preserveAspectRatio = 'xMidYMid ' + clean.preserveAspectRatio;
+    clean.preserveAspectRatio = 'xMidYMid ' + preserve;
   }
 
   return clean;

--- a/index.js
+++ b/index.js
@@ -79,7 +79,8 @@ function prepare(props) {
   // specified with align information. So we need to support this behavior and
   // correctly default to `xMidYMid [mode]`.
   //
-  if ('preserveAspectRatio' in clean && !~clean.preserveAspectRatio.indexOf(' ')) {
+  const preserve = clean.preserveAspectRatio;
+  if (preserve && preserve !== 'none' && !~preserve.indexOf(' ')) {
     clean.preserveAspectRatio = 'xMidYMid ' + clean.preserveAspectRatio;
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -311,6 +311,12 @@ describe('@ux/svg', function () {
       assume(html).to.include('preserveAspectRatio="xMidYMid meet"');
     });
 
+    it('correctly supports preserveAspectRatio="none"', function () {
+      const html = shallow(<Svg preserveAspectRatio="none" />).html();
+
+      assume(html).to.include('preserveAspectRatio="none"');
+    });
+
     it('renders with aria roles when an title is encountered', function () {
       const html = shallow(<Svg title="accessibility title here" />).html();
 


### PR DESCRIPTION
As per title,  Do no prefix `none` for preserveAspectRatio