### PR TITLE
Adding peerDependenciesMeta information

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
     "react": "*",
     "react-native-svg": "*"
   },
+  "peerDependenciesMeta": {
+    "react-native-svg": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@babel/cli": "^7.1.2",
     "@babel/core": "^7.1.2",
@@ -79,6 +84,8 @@
     ]
   },
   "nyc": {
-    "exclude": ["index.d.ts"]
+    "exclude": [
+      "index.d.ts"
+    ]
   }
 }


### PR DESCRIPTION
 This will make `react-native-svg` effectively optional, and avoid the warnings when installing `svgs` on web projects.

![Screen Shot 2020-01-15 at 12 22 03 PM](https://user-images.githubusercontent.com/28530/72468653-80919980-3792-11ea-82d2-1b5f8ad57969.png)

This is supported since npm 6.11: https://github.com/npm/cli/releases/tag/v6.11.0
yarn docs (but npm supports it as well as you can see on the previous link): https://next.yarnpkg.com/configuration/manifest#peerDependenciesMeta
example: https://github.com/knex/knex/blob/master/package.json#L55-L71